### PR TITLE
Pre election improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_with = "3.4.0"
 sqlx = { version = "0.7.1", features=["postgres", "runtime-tokio", "macros", "chrono", "uuid", "tls-rustls"]}
 time = "0.3.30"
 tokio = { version = "1.32.0", features = ["macros", "io-util", "rt-multi-thread"]}
-tower = { version = "0.4.13", features = ["util"]}
+tower = { version = "0.4.13", features = ["util", "limit", "buffer"]}
 tower-cookies = "0.9.0"
 tower-http = { version = "0.4.4", features = ["fs"]}
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] }

--- a/migrations/20241112203454_add_draws.down.sql
+++ b/migrations/20241112203454_add_draws.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+
+ALTER TABLE candidate_result_data
+DROP COLUMN IF EXISTS is_draw;

--- a/migrations/20241112203454_add_draws.up.sql
+++ b/migrations/20241112203454_add_draws.up.sql
@@ -1,0 +1,11 @@
+-- Add up migration script here
+
+ALTER TABLE candidate_result_data
+ADD is_draw boolean;
+
+UPDATE candidate_result_data
+SET is_draw = false -- Defaulting to false for old votings
+WHERE is_draw IS NULL;
+
+ALTER TABLE candidate_result_data
+ALTER COLUMN is_draw SET NOT NULL;

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,7 +12,7 @@ pub type TokenId = i32;
 pub type Alias = Option<String>;
 
 static CHARSET: &[u8] = b"0123456789abcdefghijklmnopqrstuvxyz";
-static TOKEN_LENGTH: usize = 6;
+static TOKEN_LENGTH: usize = 9;
 
 pub fn generate_token() -> String {
     let mut rng = rand::thread_rng();

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use float_cmp::{approx_eq};
+use float_cmp::approx_eq;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::iter;
@@ -236,6 +236,7 @@ pub struct VoteCastStatus {
 pub struct CandidateResultData {
     pub name: CandidateId,
     pub vote_count: f64,
+    pub is_draw: bool,
 }
 
 impl PartialEq for CandidateResultData {

--- a/src/templates/components/voting-list-draft-and-closed.html
+++ b/src/templates/components/voting-list-draft-and-closed.html
@@ -123,6 +123,9 @@
                 {% if candidate.is_selected %}
                 (valittu)
                 {% endif %}
+                {% if candidate.data.is_draw %}
+                🎲
+                {% endif %}
               </td>
               {% if !voting.hide_vote_counts %}
               <td>{{ "{:.4}"|format(candidate.data.vote_count) }}</td>
@@ -135,6 +138,9 @@
               <td class="candidate-name">
                 {{ candidate_data.name }}
                 (pudonnut)
+                {% if candidate_data.is_draw %}
+                🎲
+                {% endif %}
               </td>
               {% match login_state %}
               {% when LoginState::Admin %}


### PR DESCRIPTION
- Add 🎲emoji when RNG is used as a tiebreaker
- Add ratelimit of 100 req/s to admin and user login routes
- Increase token length to 9 from 6